### PR TITLE
Add React/Next.js, TypeScript, Python, Go production rules

### DIFF
--- a/rules-mdc/go-production.mdc
+++ b/rules-mdc/go-production.mdc
@@ -1,0 +1,15 @@
+---
+description: Go production rules — idiomatic, error-safe Go
+globs: **/*.go, !**/*_test.go
+alwaysApply: true
+---
+
+# Go Production Rules
+
+- Never ignore a returned error with _. Every error must be handled or returned.
+- Wrap errors with context: return fmt.Errorf("functionName: %w", err).
+- Define interfaces at the consumer package. Keep interfaces to 1-2 methods.
+- Every I/O function takes ctx context.Context as first parameter. Never store context in a struct.
+- Every goroutine has a clear owner and shutdown path. Use errgroup for coordinated groups.
+- Never positional struct initialization. Always name fields.
+- Table-driven tests: tests := []struct{name, input, expected} + t.Run(tt.name, ...).

--- a/rules-mdc/python-production.mdc
+++ b/rules-mdc/python-production.mdc
@@ -1,0 +1,15 @@
+---
+description: Python production rules for backend services
+globs: **/*.py, !**/migrations/**, !**/__pycache__/**
+alwaysApply: true
+---
+
+# Python Production Rules
+
+- Every function signature must include type hints for all parameters and return type.
+- Never use bare except: or except Exception: without re-raising or logging.
+- Use Pydantic BaseModel for data crossing API boundaries. Use @dataclass for internal structures.
+- Pass dependencies as function parameters. Never read from global variables in business logic.
+- Always use pathlib.Path. Use / operator for path joining.
+- Never time.sleep() in async context. Use asyncio.sleep().
+- Validate all env vars at startup. Never os.environ.get("FOO") with silent default in business logic.

--- a/rules-mdc/react-nextjs.mdc
+++ b/rules-mdc/react-nextjs.mdc
@@ -1,0 +1,15 @@
+---
+description: React and Next.js App Router production rules
+globs: **/*.tsx, **/*.jsx, src/**/*.ts
+alwaysApply: true
+---
+
+# React + Next.js App Router Rules
+
+- Default to Server Components. Add "use client" only when you need hooks, browser APIs, or event handlers.
+- Fetch data in Server Components or page.tsx. Never fetch in useEffect.
+- Use server actions for mutations — not API routes called from client components.
+- One component per file. File name = component name (PascalCase). No default exports.
+- Define explicit interface Props for every component. Never use any as a prop type.
+- Every route with async data needs a sibling loading.tsx and error.tsx.
+- Use next/image instead of img. Use next/font instead of Google Fonts link tags.

--- a/rules-mdc/typescript-strict.mdc
+++ b/rules-mdc/typescript-strict.mdc
@@ -1,0 +1,15 @@
+---
+description: TypeScript strict-mode production rules
+globs: **/*.ts, **/*.tsx, !**/*.test.ts, !**/*.spec.ts
+alwaysApply: true
+---
+
+# TypeScript Strict Mode Rules
+
+- tsconfig.json must include "strict": true. Never disable strict checks.
+- No any. Use unknown + type guards, or as Type only at I/O boundaries.
+- Every exported function needs an explicit return type, including async (Promise<T>).
+- Model state as discriminated unions, not { data?: T; loading: boolean; error?: E }.
+- Use Readonly<T> for immutable data. Use as const for config objects.
+- Validate env vars at startup with zod. Never access process.env directly in business logic.
+- No TypeScript enum. Use const object + typeof union instead.


### PR DESCRIPTION
## Adding 4 production-tested .mdc rules

These rules follow the existing format in this repo (frontmatter with description, globs, alwaysApply).

**Files added:**
- `react-nextjs.mdc` — React + Next.js App Router (Server Components, data fetching, error states)
- `typescript-strict.mdc` — TypeScript strict mode (no-any, discriminated unions, typed env)
- `python-production.mdc` — Python backend (type hints, no bare except, Pydantic, pathlib)
- `go-production.mdc` — Go (error handling, interfaces, context propagation, goroutine ownership)

Each rule targets the specific failure mode most common in AI-generated code for that stack.

These are samples from the [Cursor Rules Pack](https://oliviacraftlat.gumroad.com/l/wyaeil) — a complete pack of 50 rules across 14 stacks.